### PR TITLE
docs: package overview pages, per-module API, live-reload serve

### DIFF
--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -8,6 +8,7 @@ theme:
   features:
     - navigation.tabs
     - navigation.sections
+    - navigation.indexes
     - content.code.copy
     - search.suggest
 
@@ -48,6 +49,9 @@ markdown_extensions:
           class: mermaid
           # Note: this is causing yaml lint issues in VSCode, but works fine in MkDocs build
           format: !!python/name:pymdownx.superfences.fence_code_format
+  - admonition
+  - tables
+  - pymdownx.details
 
 extra_javascript:
   # MathJax config must come before the runtime
@@ -61,13 +65,18 @@ extra_css:
   - stylesheets/extra.css
 
 plugins:
-  - search
+  - gen-files:
+      scripts:
+        - tools/build_docs.py
+  - literate-nav:
+      nav_file: SUMMARY.md
   - mkdocstrings:
       handlers:
         python:
           paths: [src]
           options:
             docstring_style: google
+            docstring_section_style: table
             show_source: true
             show_root_heading: true
             separate_signature: true
@@ -83,8 +92,4 @@ plugins:
             show_object_full_path: false
             show_root_full_path: false
             line_length: 88
-  - gen-files:
-      scripts:
-        - tools/build_docs.py
-  - literate-nav:
-      nav_file: SUMMARY.md
+  - search

--- a/src/crv/core/__init__.py
+++ b/src/crv/core/__init__.py
@@ -1,60 +1,49 @@
 """
 Core package aggregator for CRV contracts (grammar, schemas, tables, hashing/serde, ids, versioning).
 
-Provides a single, auditable source of truth for the CRV stack's contracts:
-- Grammar (enums, EBNF, normalization helpers).
-- Typed schemas (payloads, decisions, rows) with validators.
-- Table descriptors (for IO backends to materialize datasets).
-- Canonical JSON and hashing utilities.
-- Typed IDs/aliases and schema versioning metadata.
+## Contracts (single source of truth)
+- Grammar — enums, EBNF, normalization helpers.
+- Schemas — typed models (payloads, decisions, rows) with validators.
+- Tables — descriptors for IO backends to materialize datasets.
+- Hashing/Serde — canonical JSON utilities.
+- IDs/Versioning — typed IDs, schema version metadata.
 
-Notes:
-    - Zero-IO policy: stdlib + pydantic only; no file/network IO.
-    - Naming policy: enum `.value` and field/column names are lower_snake.
-    - Canonical-only GraphEdit operations are enforced (see schema.GraphEdit).
-    - Unified identity_edges table: differentiate semantics via `edge_kind`.
+## Notes
+- Zero‑IO policy: stdlib + pydantic only; no file/network IO.
+- Naming policy: enum `.value` and field/column names are lower_snake.
+- GraphEdit: canonical‑only operations enforced (see schema.GraphEdit).
+- identity_edges unified table: differentiate semantics via `edge_kind`.
 
-Downstream usage:
-    - crv.io:
-        Builds Parquet/Arrow schemas/manifests from `tables` and validates rows
-        produced by other packages against `schema` models.
-    - crv.world:
-        Emits rows conforming to core `schema` (e.g., identity_edges, exchange)
-        using normalization helpers from `grammar`.
-    - crv.mind:
-        Produces `DecisionHead` and `RepresentationPatch` instances validated by
-        core schemas and serialized using canonical JSON for hashing.
-    - crv.lab / crv.viz:
-        Import enums and row models for typed EDSL tasks and dashboards; rely on
-        `edge_kind` (RepresentationEdgeKind) to filter identity edges.
+## Downstream usage
+- crv.io — builds Parquet/Arrow schemas/manifests from `tables` and validates rows against `schema`.
+- crv.world — emits rows conforming to core `schema` (e.g., identity_edges, exchange) using `grammar`.
+- crv.mind — produces `DecisionHead` and `RepresentationPatch` instances; serializes via canonical JSON for hashing.
+- crv.lab / crv.viz — import enums/row models for EDSL tasks and dashboards; rely on `edge_kind` to filter identity edges.
 
-Examples:
-    Basic normalization, key building, and schema validation.
+## Examples
+```python
+# Basic normalization, key building, and schema validation.
+from crv.core.grammar import ActionKind, action_kind_from_value, canonical_action_key
+action_kind_from_value("acquire_token") == ActionKind.ACQUIRE_TOKEN  # True
+canonical_action_key(ActionKind.ACQUIRE_TOKEN, token_id="Alpha")  # 'acquire_token:token_id=Alpha'
 
-    >>> from crv.core.grammar import ActionKind, action_kind_from_value, canonical_action_key
-    >>> action_kind_from_value("acquire_token") == ActionKind.ACQUIRE_TOKEN
-    True
-    >>> canonical_action_key(ActionKind.ACQUIRE_TOKEN, token_id="Alpha")
-    'acquire_token:token_id=Alpha'
+# Create a typed identity edge row (unified identity_edges).
+from crv.core.schema import IdentityEdgeRow
+row = IdentityEdgeRow(
+    tick=1,
+    observer_agent_id="i1",
+    edge_kind="object_to_positive_valence",
+    token_id="Alpha",
+    edge_weight=0.6,
+)
+row.edge_kind  # 'object_to_positive_valence'
+```
 
-    Create a typed identity edge row (unified identity_edges).
-
-    >>> from crv.core.schema import IdentityEdgeRow
-    >>> row = IdentityEdgeRow(
-    ...     tick=1,
-    ...     observer_agent_id="i1",
-    ...     edge_kind="object_to_positive_valence",
-    ...     token_id="Alpha",
-    ...     edge_weight=0.6,
-    ... )
-    >>> row.edge_kind
-    'object_to_positive_valence'
-
-References:
-    - Grammar and helpers: src/crv/core/grammar.py
-    - Schemas: src/crv/core/schema.py
-    - Tables: src/crv/core/tables.py
-    - Hashing/serde: src/crv/core/hashing.py, src/crv/core/serde.py
-    - IDs/typing: src/crv/core/ids.py, src/crv/core/typing.py
-    - Versioning/constants/errors: src/crv/core/versioning.py, src/crv/core/constants.py, src/crv/core/errors.py
+## References
+- Grammar and helpers: [grammar](grammar.md)
+- Schemas: [schema](schema.md)
+- Tables: [tables](tables/index.md)
+- Hashing/Serde: [hashing](hashing.md), [serde](serde.md)
+- IDs/Typing: [ids](ids.md), [typing](typing.md)
+- Versioning/Constants/Errors: [versioning](versioning.md), [constants](constants.md), [errors](errors.md)
 """

--- a/src/crv/io/__init__.py
+++ b/src/crv/io/__init__.py
@@ -1,44 +1,60 @@
 """
 crv.io — Canonical IO layer for CRV datasets.
 
-Responsibilities
+## Responsibilities
 - Provide a Polars/Arrow-first IO layer that materializes canonical tables defined in crv.core.tables.
 - Guarantee append-only semantics, atomic tmp→ready file renames, per-table manifests, tick-bucket partitioning, and lightweight schema validation against crv.core descriptors.
 - Keep crv.core as the single source of truth for enums, schemas, table descriptors, IDs, and versioning.
 
-Public API
-- IoSettings: Configuration for IO behavior (defaults sourced from crv.core.constants).
-- Dataset: Facade bound to a run that supports append/scan/read/manifest operations.
+## Public API
+- IoSettings — Configuration for IO behavior (defaults sourced from crv.core.constants).
+- Dataset — Facade bound to a run that supports append/scan/read/manifest operations.
 
-Source of truth and dependencies
+## Source of truth and dependencies
 - crv.core.grammar.TableName is the canonical table name enum; docstrings and type hints refer to it.
 - crv.core.tables provides TableDescriptor instances (columns/dtypes/required/nullable/partitioning=["bucket"]/version=SCHEMA_V).
 - crv.core.ids provides typed identifiers (e.g., RunId) used in annotations and docs.
 - crv.core.versioning provides SCHEMA_V embedded in Parquet key-value metadata.
 - crv.core.errors and crv.core.schema define core normalization/validation semantics; crv.io raises Io* errors for IO-layer failures.
 
-Import DAG discipline
+## Import DAG discipline
 - Depends only on stdlib, polars/pyarrow (and optionally fsspec later), and crv.core.*.
 - MUST NOT import higher layers: world, mind, lab, viz, or app.
 
-Example
-    >>> import polars as pl
-    >>> from crv.io import IoSettings, Dataset
-    >>> from crv.core.grammar import TableName
-    >>> settings = IoSettings(root_dir="out", tick_bucket_size=100)
-    >>> ds = Dataset(settings, run_id="20250101-000000")
-    >>> df = pl.DataFrame({
-    ...     "tick": [0, 1, 2, 101],
-    ...     "observer_agent_id": ["A0", "A1", "A2", "A0"],
-    ...     "edge_kind": ["self_to_object"] * 4,
-    ...     "edge_weight": [0.0, 0.1, 0.2, 0.3],
-    ... })
-    >>> ds.append(TableName.IDENTITY_EDGES, df)  # doctest: +SKIP
+## Examples
+```python
+import polars as pl
+from crv.io import IoSettings, Dataset
+from crv.core.grammar import TableName
 
-Notes
+settings = IoSettings(root_dir="out", tick_bucket_size=100)  # doctest: +SKIP
+ds = Dataset(settings, run_id="20250101-000000")  # doctest: +SKIP
+df = pl.DataFrame({  # doctest: +SKIP
+    "tick": [0, 1, 2, 101],
+    "observer_agent_id": ["A0", "A1", "A2", "A0"],
+    "edge_kind": ["self_to_object"] * 4,
+    "edge_weight": [0.0, 0.1, 0.2, 0.3],
+})
+ds.append(TableName.IDENTITY_EDGES, df)  # doctest: +SKIP
+```
+
+## Notes
 - IO write path: tmp parquet → fsync → os.replace(tmp, final) on the same filesystem for atomicity.
 - Partitioning: bucket = tick // IoSettings.tick_bucket_size; bucket dirs are zero‑padded (e.g., bucket=000123).
 - Manifests: JSON per table tracks partitions and parts and is used for pruning in scan().
+
+## References
+- [artifacts](artifacts.md)
+- [config](config.md)
+- [dataset](dataset.md)
+- [errors](errors.md)
+- [fs](fs.md)
+- [manifest](manifest.md)
+- [paths](paths.md)
+- [read](read.md)
+- [run_manifest](run_manifest.md)
+- [validate](validate.md)
+- [write](write.md)
 """
 
 from __future__ import annotations

--- a/src/crv/lab/__init__.py
+++ b/src/crv/lab/__init__.py
@@ -1,0 +1,45 @@
+"""
+crv.lab — Policy building, tasks, probes, and audit (IO‑first helpers).
+
+## Responsibilities
+- Build and manage persona policies for offline/remote elicitation and fast sweeps.
+- Define tasks and probes for controlled scenario generation and auditing.
+- Produce tidy artifacts and (optionally) index decisions/policy into canonical IO tables (crv.io).
+- Remain read‑write at the artifact layer, but avoid duplicating world logic.
+
+## Public API
+- io_helpers — IO‑first helpers for writing/reading lab artifacts.
+- policy_builder — Persona policy authoring/elicitation (remote/local).
+- tasks — Orchestration for scenario bundles and runner glue.
+- probes — Probes and audits that summarize runs.
+- audit — Higher‑level audit/report writers.
+
+## Import DAG discipline
+- Depends on: stdlib, crv.core, crv.io (Dataset), optionally pydantic/polars.
+- Must not import crv.world runtime; any world reading should use IO via crv.io selectors.
+- Must not import crv.viz dashboards (viz remains read‑only and can use lab outputs).
+
+## Examples
+```python
+# Write a tidy artifact for a lab sweep (IO-first)  # doctest: +SKIP
+from crv.lab.io_helpers import write_tidy_artifact  # doctest: +SKIP
+from crv.io import IoSettings, Dataset  # doctest: +SKIP
+settings = IoSettings(root_dir="runs/out")  # doctest: +SKIP
+ds = Dataset(settings, run_id="demo_abcdef")  # doctest: +SKIP
+write_tidy_artifact(ds, payload={"persona": "baseline", "result": "ok"})  # doctest: +SKIP
+```
+
+## References
+- [audit](audit.md)
+- [cli](cli.md)
+- [io_helpers](io_helpers.md)
+- [modelspec](modelspec.md)
+- [personas](personas.md)
+- [policy_builder](policy_builder.md)
+- [policy](policy.md)
+- [probes](probes.md)
+- [scenarios](scenarios.md)
+- [survey](survey.md)
+- [surveys](surveys.md)
+- [tasks](tasks.md)
+"""

--- a/src/crv/mind/__init__.py
+++ b/src/crv/mind/__init__.py
@@ -1,0 +1,40 @@
+"""
+crv.mind — Deterministic oracle batching, signatures, and ReAct controller (IO logging).
+
+## Responsibilities
+- Provide deterministic oracle batching with cache for reproducible cognition traces.
+- Define persona/signature scaffolding and a simple ReAct-style controller.
+- Log LLM/tool calls to canonical IO (oracle_calls) with timing and cache provenance.
+
+## Public API
+- OracleBatcher — Batched requests with sqlite cache and deterministic behavior.
+- signatures — Signature descriptors/types for prompts and tools.
+- react_controller — Step‑level coordination of tool use with guardrails.
+- tools — Optional adapters (e.g., mem0 client) and read helpers (world_read).
+
+## Import DAG discipline
+- Depends on: stdlib, crv.core, optionally pydantic/sqlite3; crv.io when IO logging is enabled.
+- Must not import crv.world runtime; read helpers operate via crv.io only.
+- External services (LLMs, memory) must be optional and guarded.
+
+## Examples
+```python
+# Log oracle calls to IO (oracle_calls table)  # doctest: +SKIP
+from crv.mind.oracle import OracleBatcher
+from crv.io import IoSettings, Dataset
+batcher = OracleBatcher(io_settings=IoSettings(root_dir="runs/out"),
+                        run_id="demo_abcdef")  # doctest: +SKIP
+_ = batcher.ask(engine="gpt-4o", signature_id="sign_v1", value={"q": "hello"})  # doctest: +SKIP
+batcher.flush()  # writes to TableName.ORACLE_CALLS via Dataset  # doctest: +SKIP
+```
+
+## References
+- [cache](cache.md)
+- [compile](compile.md)
+- [eval](eval.md)
+- [oracle_types](oracle_types.md)
+- [oracle](oracle.md)
+- [programs](programs.md)
+- [react_controller](react_controller.md)
+- [signatures](signatures.md)
+"""

--- a/src/crv/viz/__init__.py
+++ b/src/crv/viz/__init__.py
@@ -1,0 +1,52 @@
+"""
+crv.viz — Read‑only transforms and dashboards over IO datasets.
+
+## Responsibilities
+- Provide composable, Polars‑first transforms for analysis of canonical tables.
+- Offer chart/layer primitives and dashboards for common exploratory views.
+- Never mutate canonical IO; read‑only by contract.
+
+## Public API
+- transforms — Helpers to assemble analysis frames from crv.io tables.
+- layers — Altair layer primitives and encodings.
+- dashboards — Ready‑to‑use dashboards that wire transforms and layers.
+- networks — Network views for identity edges.
+- timeseries — Time‑based views (e.g., value trajectories).
+- distributions — Distribution plots over canonical metrics.
+
+## Import DAG discipline
+- Depends on: crv.io (Dataset scans), polars, altair (and stdlib).
+- Must not write to IO or modify manifests.
+- Must not import crv.world or crv.lab at runtime (only their artifacts via IO).
+
+## Examples
+```python
+# Build a lightweight identity-edges view for a dashboard  # doctest: +SKIP
+from crv.io import IoSettings, Dataset
+import polars as pl
+ds = Dataset(IoSettings(root_dir="runs/out"), run_id="demo_abcdef")
+lf = (
+    ds.scan("identity_edges", columns=["tick","observer_agent_id","edge_kind","token_id","edge_weight"])
+      .filter(pl.col("edge_kind") == "self_to_object")
+      .select(
+          pl.col("tick").alias("t"),
+          pl.col("observer_agent_id").alias("agent_id"),
+          pl.col("token_id"),
+          pl.col("edge_weight").alias("self_to_object_strength"),
+      )
+)  # doctest: +SKIP
+df = lf.collect()  # doctest: +SKIP
+```
+
+## References
+- [base](base.md)
+- [dashboards](dashboards.md)
+- [distributions](distributions.md)
+- [events](events.md)
+- [identity](identity.md)
+- [layers](layers.md)
+- [networks](networks.md)
+- [save](save.md)
+- [theme](theme.md)
+- [timeseries](timeseries.md)
+"""

--- a/src/crv/world/__init__.py
+++ b/src/crv/world/__init__.py
@@ -1,0 +1,44 @@
+"""
+crv.world — Deterministic ABM world, agents, events, and visibility/observation rules.
+
+## Responsibilities
+- Execute the barriered CRV loop (Context → Representation → Valuation → Action) deterministically.
+- Manage agents, events, and observation/visibility rules (delays, channels, topology).
+- Integrate IO-first writing via crv.io (append-only parquet + per-table manifests).
+- Preserve reproducibility (seeded RNGs, run manifests, provenance).
+
+## Public API
+- model — World model and step loop mechanics.
+- agents — Agent scaffolding and state.
+- observation_rules — Visibility/delivery policies (global, group, delayed, topology).
+- sim — Entry points for running simulations and small demos.
+- sweep — Simple sweep harnesses (parameter scans) when applicable.
+
+## Import DAG discipline
+- Depends on: stdlib, crv.core (contracts), crv.io (IO-first writers), mesa (runtime), and local modules.
+- Must not import crv.lab or crv.mind at runtime. Interactions happen via data contracts (files) or injected interfaces.
+- crv.viz reads artifacts only and must not be imported here.
+
+## Examples
+```python
+# Minimal sketch (API varies by version)  # doctest: +SKIP
+from crv.world.model import CRVModel
+from crv.io import IoSettings
+from crv.core.ids import RunId
+
+settings = IoSettings.load()
+m = CRVModel(io_settings=settings, run_id=RunId("demo_abcdef"))
+m.step()  # advance one tick
+```
+
+## References
+- [agents](agents.md)
+- [config](config.md)
+- [data](data.md)
+- [events](events.md)
+- [mesa_data](mesa_data.md)
+- [model](model.md)
+- [observation_rules](observation_rules.md)
+- [sim](sim.md)
+- [sweep](sweep.md)
+"""

--- a/tools/generate_docs.sh
+++ b/tools/generate_docs.sh
@@ -42,7 +42,8 @@ case "$cmd" in
     ;;
   serve)
     # Local dev server with correct PYTHONPATH and guard
-    uv run mkdocs serve "$@"
+    # Watch src (code) and build script for live reload in addition to docs/
+    uv run mkdocs serve -w src -w tools/build_docs.py "$@"
     ;;
   *)
     echo "Usage: $0 [build|serve] [-- mkdocs args]" >&2


### PR DESCRIPTION
## Summary

Restructure the documentation site and API reference to:

- Render package pages as overview-only (no member lists), using standardized Markdown sections and a “References” section linking to concrete module API pages.
- Keep module pages as the single source of truth for symbols (classes/functions), removing duplication.
- Add a live-reload serve mode that watches `src/` and `tools/build_docs.py` for fast authoring.
- Fix relative links in `crv.core` package references and normalize package `__init__` docstrings across `crv.io`, `crv.lab`, `crv.mind`, `crv.viz`, and `crv.world`.

## Motivation

Previously, package pages duplicated members (e.g., `IoSettings` and `Dataset` appeared both on the package page and their module pages), and package docstrings’ headings/lists sometimes rendered as plain text. This change delivers a DRY, scalable information architecture:

- Package pages remain readable, human-oriented overviews.
- Each symbol has a single, canonical module page.
- Authors iterate faster using `mkdocs serve` with watcher flags.

## Scope of Changes (by file)

- `tools/build_docs.py` (modified)
  - Generate package index pages with mkdocstrings filters: `['!.*']` (hide members on package pages).
  - Continue generating per-module pages (no change to module directives).
  - Maintain literate-nav generation (`SUMMARY.md`) with a clean hierarchy: package header → package index → module pages (short labels).
- `tools/generate_docs.sh` (modified)
  - Add `serve` subcommand for live reload on docs and code:
    - `uv run mkdocs serve -w src -w tools/build_docs.py`
- `src/crv/core/__init__.py` (modified)
  - Replace “References” bullets with working relative links:
    - `grammar.md`, `schema.md`, `tables/index.md`, `hashing.md`, `serde.md`, `ids.md`, `typing.md`, `versioning.md`, `constants.md`, `errors.md`.
- `src/crv/io/__init__.py` (modified)
  - Normalize headings (Markdown); add “References” linking to:
    - `artifacts.md`, `config.md`, `dataset.md`, `errors.md`, `fs.md`, `manifest.md`, `paths.md`, `read.md`, `run_manifest.md`, `validate.md`, `write.md`.
- `src/crv/lab/__init__.py` (modified)
  - Normalize headings; replace “See Also” with “References” linking to:
    - `audit.md`, `cli.md`, `io_helpers.md`, `modelspec.md`, `personas.md`, `policy_builder.md`, `policy.md`, `probes.md`, `scenarios.md`, `survey.md`, `surveys.md`, `tasks.md`.
- `src/crv/viz/__init__.py` (modified)
  - Normalize headings; add “References” linking to:
    - `base.md`, `dashboards.md`, `distributions.md`, `events.md`, `identity.md`, `layers.md`, `networks.md`, `save.md`, `theme.md`, `timeseries.md`.
- `src/crv/mind/__init__.py` (modified)
  - Normalize headings; add “References” linking to:
    - `cache.md`, `compile.md`, `eval.md`, `oracle_types.md`, `oracle.md`, `programs.md`, `react_controller.md`, `signatures.md`.
- `src/crv/world/__init__.py` (modified)
  - Standardize package overview docstring; add “References” linking to:
    - `agents.md`, `config.md`, `data.md`, `events.md`, `mesa_data.md`, `model.md`, `observation_rules.md`, `sim.md`, `sweep.md`.

## Approach

- Package pages: overview-only render using mkdocstrings directive with:
  ```
  options:
    show_submodules: false
    members_order: source
    show_source: false
    show_if_no_docstring: true
    filters:
      - '!.*'
  ```
  This hides package members while preserving the package docstring. Navigation lists the package header (link target = package index) and module pages beneath.
- Package docstrings: standard Markdown sections (Summary; “## Responsibilities”; “## Public API”; “## Import DAG discipline”; “## Examples”; “## References”).
- Live dev loop: `tools/generate_docs.sh serve` watches `src/` and `tools/build_docs.py` for fast regeneration.

## User Impact

- Better UX for API browsing: package index pages are clean overviews; modules hold details.
- Faster authoring iteration thanks to live reload while editing both code and doc generation logic.
- No runtime behavior changes.

## API / DB Changes

- None.

## Backward Compatibility / Migration

- None. Documentation-only changes.

## Performance

- Build time unchanged; developer iteration time improved via live reload on code/doc-generation changes.

## Security / Privacy

- N/A (documentation changes only).

## Testing Plan

- Strict docs build:
  ```bash
  bash tools/generate_docs.sh
  ```
  - Confirms no unresolved links or mkdocs warnings.
- Local preview:
  ```bash
  bash tools/generate_docs.sh serve
  ```
  - Ensure package pages show overviews only, module links resolve, and live reload triggers on edits to `src/` and `tools/build_docs.py`.
- Spot-check packages (core, io, world, lab, mind, viz):
  - Confirm “References” link lists align with present modules.
  - Confirm no duplicated symbols on package pages (e.g., `IoSettings` only on `config.md`, `Dataset` only on `dataset.md`).

## Rollout / Ops

- Use `serve` mode during active docs editing.
- Keep strict build in CI for link/style regressions.

## Docs / Changelog

- Standardized package docstrings for `crv.io`, `crv.lab`, `crv.mind`, `crv.viz`, `crv.world`.
- Fixed relative links in `crv.core` package references.
- Updated docs generator and wrapper to support package-overview-only pages and live-reload serve.

## Screenshots / Recordings (optional)

- N/A

## Risks and Mitigations

- Risk: Missing or stale links in “References”.
  - Mitigation: Strict build surfaces unresolved links; spot-checked in local preview.
- Risk: Future packages accidentally re-show members on package pages.
  - Mitigation: `filters: ['!.*']` applied uniformly in generator.
- Risk: Some gen-files changes not reloaded.
  - Mitigation: Watching `tools/build_docs.py` and `src/` by default; pass additional `-w` paths as needed.

## References

- Build pipeline:
  - `tools/build_docs.py`
  - `tools/generate_docs.sh`

## Checklist

- [x] Scope is clear; non-goals noted
- [x] Linked references added (plans/ADRs)
- [x] No breaking runtime changes
- [x] No API/DB changes
- [x] Strict docs build passes
- [x] Live reload (serve) watches `src/` and `tools/build_docs.py`
- [x] Docs updated and consistent; package pages overview-only
- [x] CI (docs build) expected to be green
